### PR TITLE
bugfix pattern construction

### DIFF
--- a/ESGConfigParser/__init__.py
+++ b/ESGConfigParser/__init__.py
@@ -222,7 +222,7 @@ class SectionParser(ConfigParser):
         # Translate all patterns matching %(name)s
         pattern = re.sub(re.compile(r'%\(([^()]*)\)s'), r'(?P<\1>[\w.-]+)', pattern)
         # Add ending version pattern if needed and missing
-        if add_ending_version and 'version' not in pattern:
+        if add_ending_version and '<version>' not in pattern:
             pattern = '{}{}(?P<version>v[\d]+|latest)$'.format(pattern, sep)
         # Add ending filename pattern if needed and missing
         if add_ending_filename and 'filename' not in pattern:


### PR DESCRIPTION
The test which I have modified was breaking the appending of the version number to the dataset ID pattern for CORDEX because `rcm_version` is one of the facets.