### PR TITLE
Attempt to fix "Upgraded to use Python3 #82"

### DIFF
--- a/ESGConfigParser/__init__.py
+++ b/ESGConfigParser/__init__.py
@@ -211,16 +211,16 @@ class SectionParser(ConfigParser):
         # Remove underscore from latest mandatory pattern to allow optional brackets
         pattern = re.sub(re.compile(r'%\(([^()]*)\)s\('), r'(?P<\1>[^-_]+)(', pattern)
         # Translate all patterns matching %(digit)s
-        pattern = re.sub(re.compile(r'%\((digit)\)s'), r'[\d]+', pattern)
+        pattern = re.sub(re.compile(r'%\((digit)\)s'), r'[\\d]+', pattern)
         # Translate all patterns matching %(string)s
-        pattern = re.sub(re.compile(r'%\((string)\)s'), r'[\w-]+', pattern)
+        pattern = re.sub(re.compile(r'%\((string)\)s'), r'[\\w-]+', pattern)
         # Translate %(root)s variable if exists but not required. Can include the project name.
         if re.compile(r'%\((root)\)s').search(pattern):
             pattern = re.sub(re.compile(r'%\((root)\)s'), r'(?P<\1>[\w./-]+)', pattern)
         # Constraint on %(version)s number
-        pattern = re.sub(re.compile(r'%\((version)\)s'), r'(?P<\1>v[\d]+|latest)', pattern)
+        pattern = re.sub(re.compile(r'%\((version)\)s'), r'(?P<\1>v[\\d]+|latest)', pattern)
         # Translate all patterns matching %(name)s
-        pattern = re.sub(re.compile(r'%\(([^()]*)\)s'), r'(?P<\1>[\w.-]+)', pattern)
+        pattern = re.sub(re.compile(r'%\(([^()]*)\)s'), r'(?P<\1>[\\w.-]+)', pattern)
         # Add ending version pattern if needed and missing
         if add_ending_version and 'version' not in pattern:
             pattern = '{}{}(?P<version>v[\d]+|latest)$'.format(pattern, sep)

--- a/ESGConfigParser/constants.py
+++ b/ESGConfigParser/constants.py
@@ -8,4 +8,4 @@
 """
 
 # Program version
-VERSION = '0.1.17'
+VERSION = '0.1.18'


### PR DESCRIPTION
Hi,

i've tested this patch on a subset of the '__init__.py' file --> just patching the 'transform' method and run it using different versions of python3:

| version | no patch | patch applied |
|--------|----|-----|
| python3.4 | works | n/a |
| python3.7.8 | fails | works |
| python3.9.0 | fails | works |

A new release of the esgf-config-parser could be used on the esgf-prepare project, which hopefully fixes the bug.

BR,
Thomas


---

[att1.md](https://github.com/user-attachments/files/16496389/att1.md)


[pr1.patch](https://github.com/user-attachments/files/16496631/pr1.patch)
